### PR TITLE
Scroll to result if it's out of view.

### DIFF
--- a/powerBar.js
+++ b/powerBar.js
@@ -150,6 +150,7 @@
             this.suggestionElements[this._selectedSuggestionIndex].classList.remove('suggestion-item__active');
             this._selectedSuggestionIndex = index;
             this.suggestionElements[index].classList.add('suggestion-item__active');
+            this.suggestionElements[index].scrollIntoView();
         }
 
         get selectedSuggestionIndex() {


### PR DESCRIPTION
When using the arrows to go through the results it doesn't scroll down or up if the result's element is outside of view.