### PR TITLE
Keyboard shortcut fix for Windows

### DIFF
--- a/src/components/PowerBar.tsx
+++ b/src/components/PowerBar.tsx
@@ -67,7 +67,7 @@ export default class PowerBar extends React.Component<{}, LocalState> {
             [KEY_COMBO]: {
                 type: 'input',
                 description: 'Activation key combo. First key needs to be a modifier (shift, ctrl, alt or cmd/windows key).',
-                defaultValue: [this.isMac ? 'altKey' : 'controlKey', 'Space'],
+                defaultValue: [this.isMac ? 'altKey' : 'ctrlKey', 'Space'],
                 events: {
                     onKeyDown: this.handleSettingsInput,
                     onBlur: (e) => {


### PR DESCRIPTION
See [#14](https://github.com/jeroentvb/spicetify-power-bar/issues/14#issue-1146255285).

Will work for fresh installs only (with no existing settings left saved in local storage).